### PR TITLE
Version Bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,10 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-AbstractAlgebra = "0.42, 0.43"
+AbstractAlgebra = "0.42, 0.43, 0.44"
 Groebner = "0.8.1"
 Logging = "1.10"
-Nemo = "0.46, 0.47"
+Nemo = "0.46, 0.47, 0.48"
 Primes = "0.5"
 ProgressMeter = "1.10"
 Random = "1.10"


### PR DESCRIPTION
I would like to use some features of the updated Nemo, and AbstractAlgebra packages with https://github.com/SciML/StructuralIdentifiability.jl.

This project is restricting their version.